### PR TITLE
Fixed health overflow and excess storage

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -28,11 +28,15 @@ namespace los {
 		m_playerHealth = h;
 		m_heartCount = std::floor(h / 4);
 		
-		if (m_heartCount > 64)
+		if (m_heartCount > 64) {
+			m_playerHealth = 64 * 4;
 			m_heartCount = 64;
+		}
 
-		if (m_heartCount < 0)
+		if (m_heartCount < 0) {
+			m_playerHealth = 64 * 4;
 			m_heartCount = 0;
+		}
 	}
 
 	short UI::getPlayerHealth() {

--- a/src/ui.hpp
+++ b/src/ui.hpp
@@ -22,7 +22,7 @@ namespace los {
 		private:
 			Sprite *m_heart;
 		private:
-			signed char m_heartCount = 8;
-			signed char m_playerHealth = 8 * 4;
+			signed short m_heartCount = 8;
+			signed short m_playerHealth = 8 * 4;
 	};
 };


### PR DESCRIPTION
1. Changed declaration of m_playerHealth from signed char to signed short, making it compatible with UI::setPlayerHealth(signed short) when invoked with a parameter bigger than 127. This causes the health to no longer overflow and kill the player upon reaching 128 health (32 hearts). 
2. The explicit boundary of [0,64] hearts set in ui.cpp:31 now includes m_playerHealth as well, enforcing the boundary on the actual health value, not just the displayed hearts. Previously, the player was able to collect more than 256 health (64 hearts) but these excess hearts were simply not displayed.