### PR TITLE
Fix compilation, build on Travis CI, generate AppImage, upload to bintray.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+compiler: gcc
+sudo: require
+dist: trusty
+
+install: 
+    - sudo apt-get -y install libsdl2-image-dev libsdl2-mixer-dev
+
+script:
+  - mkdir bin
+  - cd bin
+  - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+  - make -j4
+  - make DESTDIR=appdir install ; find appdir/
+
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - make -j4
   - mkdir -p appdir/usr/bin
   - cp LegendOfSajjad appdir/usr/bin/legendofsajjad
+  - strip appdir/usr/bin/legendofsajjad
   - mkdir -p appdir/usr/share/{icons,applications}
   - cp ../res/misc/legendofsajjad.desktop appdir/usr/share/applications/
   - cp ../res/misc/legendofsajjad.desktop appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/pulseaudio/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ after_success:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage --appimage-extract
+  - rm -f ./appdir/AppRun
   - cat > ./appdir/AppRun <<\EOF
   - #!/bin/sh
   - HERE="$(dirname "$(readlink -f "${0}")")"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ script:
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
   - make DESTDIR=appdir install ; find appdir/
+  - mkdir -p appdir/usr/share/{icons,applications}
+  - cp ../res/misc/legendofsajjad.desktop appdir/usr/share/applications/
+  - cp ../res/misc/legendofsajjad.desktop appdir/
+  - cp ../res/entities/player.png appdir/legendofsajjad.png
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
@@ -20,4 +24,4 @@ after_success:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl --upload-file ./Legend*.AppImage https://transfer.sh/Legend_of_Sajjad-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ script:
   - cd bin
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
   - make -j4
-  - make DESTDIR=appdir install ; find appdir/
+  - mkdir -p appdir/usr/bin
+  - cp LegendOfSajjad appdir/usr/bin/legendofsajjad
   - mkdir -p appdir/usr/share/{icons,applications}
   - cp ../res/misc/legendofsajjad.desktop appdir/usr/share/applications/
   - cp ../res/misc/legendofsajjad.desktop appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,14 @@ after_success:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/pulseaudio/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - cat > ./appdir/AppRun <<\EOF
+  - #!/bin/sh
+  - HERE="$(dirname "$(readlink -f "${0}")")"
+  - cd "${HERE}/usr/bin"
+  - exec ./legendofsajjad "$@"
+  - EOF
+  - ./squashfs/usr/bin/linuxdeployqt ./appdir/
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Legend*.AppImage https://transfer.sh/Legend_of_Sajjad-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,10 @@ after_success:
   - export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/pulseaudio/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
-  - ls
   - # The next 3 lines are a workaround needed because the game loads its data from a path relative to cwd 
   - ./linuxdeployqt*.AppImage --appimage-extract
   - rm -f ./appdir/AppRun
-  - mv ./appdir/usr/res/misc/ ./appdir ; chmod a+x ./appdir/AppRun
+  - mv ./appdir/usr/res/misc/AppRun ./appdir ; chmod a+x ./appdir/AppRun
   - ./squashfs/usr/bin/linuxdeployqt ./appdir/
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Legend*.AppImage https://transfer.sh/Legend_of_Sajjad-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ after_success:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/pulseaudio/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
+  - ls
   - # The next 3 lines are a workaround needed because the game loads its data from a path relative to cwd 
   - ./linuxdeployqt*.AppImage --appimage-extract
   - rm -f ./appdir/AppRun

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - cp ../res/misc/legendofsajjad.desktop appdir/usr/share/applications/
   - cp ../res/misc/legendofsajjad.desktop appdir/
   - cp ../res/entities/player.png appdir/legendofsajjad.png
+  - cp -r  ../res/ appdir/usr/
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ after_success:
   - ./linuxdeployqt*.AppImage --appimage-extract
   - rm -f ./appdir/AppRun
   - mv ./appdir/usr/res/misc/AppRun ./appdir ; chmod a+x ./appdir/AppRun
-  - ./squashfs/usr/bin/linuxdeployqt ./appdir/
+  - ./squashfs-root/usr/bin/linuxdeployqt ./appdir/
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Legend*.AppImage https://transfer.sh/Legend_of_Sajjad-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,10 @@ after_success:
   - export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/pulseaudio/
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - # The next 3 lines are a workaround needed because the game loads its data from a path relative to cwd 
   - ./linuxdeployqt*.AppImage --appimage-extract
   - rm -f ./appdir/AppRun
-  - cat > ./appdir/AppRun <<\EOF
-  - #!/bin/sh
-  - HERE="$(dirname "$(readlink -f "${0}")")"
-  - cd "${HERE}/usr/bin"
-  - exec ./legendofsajjad "$@"
-  - EOF
+  - mv ./appdir/usr/res/misc/ ./appdir ; chmod a+x ./appdir/AppRun
   - ./squashfs/usr/bin/linuxdeployqt ./appdir/
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Legend*.AppImage https://transfer.sh/Legend_of_Sajjad-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ after_success:
   - ./linuxdeployqt*.AppImage --appimage-extract
   - rm -f ./appdir/AppRun
   - mv ./appdir/usr/res/misc/AppRun ./appdir ; chmod a+x ./appdir/AppRun
-  - ./squashfs-root/usr/bin/linuxdeployqt ./appdir/
+  - ./squashfs-root/usr/bin/appimagetool ./appdir/
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Legend*.AppImage https://transfer.sh/Legend_of_Sajjad-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/res/misc/AppRun
+++ b/res/misc/AppRun
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Workaround needed
+# because legendofsajjad loads its data from a path relative to
+# the current working directory (FIXME)
+HERE="$(dirname "$(readlink -f "${0}")")"
+cd "${HERE}/usr/bin"
+exec ./legendofsajjad "$@"

--- a/res/misc/legendofsajjad.desktop
+++ b/res/misc/legendofsajjad.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Legend of Sajjad
+Exec=legendofsajjad
+Icon=legendofsajjad
+Categories=Game;

--- a/src/penguin.cpp
+++ b/src/penguin.cpp
@@ -1,5 +1,7 @@
 #include "penguin.hpp"
 
+#include <cmath>
+
 #include "keyboard.hpp"
 #include "util/surfaceEditor.hpp"
 #include "util/surfaceCreator.hpp"

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3,6 +3,7 @@
 #include "sfx/soundBank.hpp"
 #include "util/surfaceEditor.hpp"
 #include "util/surfaceCreator.hpp"
+#include <cmath>
 
 #include <SDL2/SDL_image.h>
 


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.