### PR TITLE
Show the SDL_mixer error when a sound can not be played

### DIFF
--- a/src/sfx/soundBank.cpp
+++ b/src/sfx/soundBank.cpp
@@ -39,7 +39,12 @@ namespace los {
 		auto it = m_sounds.find(soundName);
 		if (it != m_sounds.end()) {
 			if (Mix_PlayChannel(-1, it->second, 0) == -1)
-				std::cerr << "SRC: soundBank.cpp\tERR: Failed to play sound " << soundName << "\n";
+				std::cerr
+				<< "SRC: soundBank.cpp\tERR: Failed to play sound "
+				<< soundName
+				<< " ("
+				<< Mix_GetError()
+				<< ")\n";
 		} else
 			std::cerr << "SRC: soundBank.cpp\tERR: Could not find sound " << soundName << "\n";
 	}

--- a/src/sfx/soundBank.cpp
+++ b/src/sfx/soundBank.cpp
@@ -38,13 +38,10 @@ namespace los {
 	void SoundBank::playSound(const SOUND soundName) {
 		auto it = m_sounds.find(soundName);
 		if (it != m_sounds.end()) {
-			if (Mix_PlayChannel(-1, it->second, 0) == -1)
-				std::cerr
-				<< "SRC: soundBank.cpp\tERR: Failed to play sound "
-				<< soundName
-				<< " ("
-				<< Mix_GetError()
-				<< ")\n";
+			if (Mix_PlayChannel(-1, it->second, 0) == -1) {
+				std::string message = "SRC: soundBank.cpp\tERR: Failed to play sound ";
+				std::cerr << message << soundName << " (" << Mix_GetError() << ")\n";
+			}
 		} else
 			std::cerr << "SRC: soundBank.cpp\tERR: Could not find sound " << soundName << "\n";
 	}


### PR DESCRIPTION
Shows the SDL_mixer error output when a sound can not be played